### PR TITLE
Refactor Flashcard Navigation and UI Layout

### DIFF
--- a/flashcards/flashcards.css
+++ b/flashcards/flashcards.css
@@ -12,11 +12,53 @@ body {
     padding-top: 2rem;
 }
 
+#flashcard-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+#prev-flashcard,
+#next-flashcard {
+    background: var(--card-bg);
+    color: var(--ejo-primary);
+    border: 2px solid var(--ejo-primary);
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    flex-shrink: 0;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+#prev-flashcard:hover:not(:disabled),
+#next-flashcard:hover:not(:disabled) {
+    background: var(--ejo-primary);
+    color: white;
+    transform: scale(1.1);
+}
+
+#prev-flashcard:disabled,
+#next-flashcard:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+    border-color: #ccc;
+    color: #ccc;
+}
+
 .flashcard-scene {
     width: clamp(300px, 90vw, 600px);
     height: clamp(200px, 50vh, 350px);
     perspective: 1000px;
-    margin: 0 auto 40px;
+    margin-bottom: 40px;
 }
 
 .flashcard {
@@ -160,6 +202,10 @@ body {
     justify-content: center;
 }
 
+.card-count-text {
+    display: none;
+}
+
 .mastery-btn {
     background: none;
     border: none;
@@ -228,8 +274,26 @@ body {
 }
 
 @media (max-width: 768px) {
+  #flashcard-container {
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 10px;
+  }
+
   .flashcard-scene {
-    margin-bottom: 30px;
+    width: 100%;
+    margin-bottom: 20px;
+    order: 1;
+  }
+
+  #prev-flashcard,
+  #next-flashcard {
+      display: flex;
+      order: 2;
+      width: 45%;
+      height: 45px;
+      border-radius: 10px;
+      font-size: 1rem;
   }
   
   .flashcard-controls {

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -30,6 +30,7 @@
       <!-- flashcards-->
       <section id="flashcards-section">
   <div id="flashcard-container">
+    <button id="prev-flashcard" type="button" aria-label="Previous Flashcard"><i class="fas fa-chevron-left"></i></button>
     <div class="flashcard-scene">
       <div class="flashcard" id="flashcard">
         <div class="card-face card-front">
@@ -44,11 +45,12 @@
         </div>
       </div>
     </div>
+    <button id="next-flashcard" type="button" aria-label="Next Flashcard"><i class="fas fa-chevron-right"></i></button>
   </div>
   <div class="flashcard-controls">
     
     <div class="progress-container">
-      <span id="current-card">1</span> out of <span id="total-cards">10</span>
+      <span class="card-count-text"><span id="current-card">1</span> out of <span id="total-cards">10</span></span>
       <button id="mastered-toggle" class="mastery-btn" title="Mark as Mastered"><i class="far fa-check-circle"></i></button>
     </div>
 
@@ -61,9 +63,7 @@
         </label>
     </div>
 
-    <button id="prev-flashcard" type="button">Previous</button>
     <button id="flip-flashcard" type="button">Flip</button>
-    <button id="next-flashcard" type="button">Next</button>
     <button id="skip-flashcard">Skip</button>
 
 


### PR DESCRIPTION
The flashcard user interface was updated to improve intuitiveness and usability on larger screens. The 'Previous' and 'Next' navigation buttons were moved from the bottom controls to the sides of the flashcard container using a flexbox layout. These buttons were also updated to use Font Awesome icons instead of text labels. On mobile devices, the buttons wrap below the card to maintain a compact layout. Additionally, the 'n out of n' card counter was hidden from the user interface. These changes were verified with Playwright scripts for both desktop and mobile viewports.

---
*PR created automatically by Jules for task [15279123185110178250](https://jules.google.com/task/15279123185110178250) started by @benduse*